### PR TITLE
Add deriving of Ord instances for private and public RSA and DSA keys types

### DIFF
--- a/Crypto/Types/PubKey/DSA.hs
+++ b/Crypto/Types/PubKey/DSA.hs
@@ -25,7 +25,7 @@ type Signature = (Integer,Integer)
 data PublicKey = PublicKey
     { public_params :: Params   -- ^ DSA parameters
     , public_y      :: Integer  -- ^ DSA public Y
-    } deriving (Show,Read,Eq,Data,Typeable)
+    } deriving (Show,Read,Eq,Ord,Data,Typeable)
 
 -- | Represent a DSA private key.
 --
@@ -34,4 +34,4 @@ data PublicKey = PublicKey
 data PrivateKey = PrivateKey
     { private_params :: Params   -- ^ DSA parameters
     , private_x      :: Integer  -- ^ DSA private X
-    } deriving (Show,Read,Eq,Data,Typeable)
+    } deriving (Show,Read,Eq,Ord,Data,Typeable)

--- a/Crypto/Types/PubKey/RSA.hs
+++ b/Crypto/Types/PubKey/RSA.hs
@@ -20,10 +20,10 @@ data PublicKey = PublicKey
     { public_size :: Int      -- ^ size of key in bytes
     , public_n    :: Integer  -- ^ public p*q
     , public_e    :: Integer  -- ^ public exponant e
-    } deriving (Show,Read,Eq,Data,Typeable)
+    } deriving (Show,Read,Eq,Ord,Data,Typeable)
 
 -- | Represent a RSA private key.
--- 
+--
 -- Only the pub, d fields are mandatory to fill.
 --
 -- p, q, dP, dQ, qinv are by-product during RSA generation,
@@ -40,7 +40,7 @@ data PrivateKey = PrivateKey
     , private_dP   :: Integer   -- ^ d mod (p-1)
     , private_dQ   :: Integer   -- ^ d mod (q-1)
     , private_qinv :: Integer   -- ^ q^(-1) mod p
-    } deriving (Show,Read,Eq,Data,Typeable)
+    } deriving (Show,Read,Eq,Ord,Data,Typeable)
 
 private_size = public_size . private_pub
 private_n    = public_n . private_pub


### PR DESCRIPTION
Key types had no Ord instance deriving so I can not use it, for example, as Map keys. I suggest that add standalone deriving in my project is bad idea.
