### PR TITLE
Support OID format for ASN1-encoded RSA keys.

### DIFF
--- a/crypto-pubkey-types.cabal
+++ b/crypto-pubkey-types.cabal
@@ -1,5 +1,5 @@
 Name:                crypto-pubkey-types
-Version:             0.4.2.3
+Version:             0.4.2.4
 Description:         Generic cryptography public keys algorithm types
 License:             BSD3
 License-file:        LICENSE
@@ -20,6 +20,7 @@ Library
                      Crypto.Types.PubKey.ECDSA
   Build-depends:     base >= 4 && < 5
                    , asn1-types >= 0.1 && < 0.4
+                   , asn1-encoding < 1.0
 
 source-repository head
   type:     git


### PR DESCRIPTION
Add support for OID format for RSA public and private keys in the fromASN1 method. OpenSSL sometimes generates keys in this format. 
