### PR TITLE
Fix ASN.1 encoding of DSA public keys

### DIFF
--- a/Crypto/Types/PubKey/DSA.hs
+++ b/Crypto/Types/PubKey/DSA.hs
@@ -23,6 +23,10 @@ module Crypto.Types.PubKey.DSA
 
 import Data.Data
 import Data.ASN1.Types
+import Data.ASN1.Encoding
+import Data.ASN1.BinaryEncoding
+import qualified Data.ByteString.Lazy as BL (toStrict)
+import Data.ASN1.BitArray
 
 -- | DSA Public Number, usually embedded in DSA Public Key
 type PublicNumber = Integer

--- a/Crypto/Types/PubKey/DSA.hs
+++ b/Crypto/Types/PubKey/DSA.hs
@@ -75,13 +75,20 @@ data PublicKey = PublicKey
 -- number together.
 instance ASN1Object PublicKey where
     toASN1 pubKey = \xs -> Start Sequence
-                         : IntVal (params_p params)
-                         : IntVal (params_q params)
-                         : IntVal (params_g params)
+                         :   Start Sequence
+                         :     OID [1,2,840,10040,4,1]
+                         :     Start Sequence
+                         :       IntVal (params_p params)
+                         :       IntVal (params_q params)
+                         :       IntVal (params_g params)
+                         :     End Sequence
+                         :   End Sequence
+                         :   BitString (BitArray 0 yBytes)
                          : End Sequence
-                         : IntVal (public_y pubKey)
                          : xs
         where params = public_params pubKey
+              yBytes = BL.toStrict $ encodeASN1 DER [ IntVal $ public_y pubKey ]
+
     fromASN1 l = case fromASN1 l of
                     Left err -> Left err
                     Right (dsaParams, ls) -> case ls of

--- a/crypto-pubkey-types.cabal
+++ b/crypto-pubkey-types.cabal
@@ -21,6 +21,7 @@ Library
   Build-depends:     base >= 4 && < 5
                    , asn1-types >= 0.1 && < 0.4
                    , asn1-encoding
+                   , bytestring
 
 source-repository head
   type:     git


### PR DESCRIPTION
The ASN.1 encoding of DSA public keys doesn't match what OpenSSL etc. seems to do.

This PR is currently incomplete - it fixes `toASN1` but not `fromASN1`.

I'm unsure whether my definition of `yBytes` is the best way to do it and also unsure about adding a dependency on `bytestring`. Perhaps there's a better way?

Comments appreciated!

Cheers,

David
