### PR TITLE
Require Cabal-Version 1.8

### DIFF
--- a/crypto-pubkey-types.cabal
+++ b/crypto-pubkey-types.cabal
@@ -10,7 +10,7 @@ Synopsis:            Generic cryptography Public keys algorithm types
 Category:            Cryptography
 Build-Type:          Simple
 Homepage:            http://github.com/vincenthz/hs-crypto-pubkey-types
-Cabal-Version:       >=1.6
+Cabal-Version:       >=1.8
 
 Library
   Exposed-modules:   Crypto.Types.PubKey.RSA


### PR DESCRIPTION
Hopefully this suppresses the following warning:
```
Warning: crypto-pubkey-types.cabal:21:34: version operators used. To use                                                                                                                                                                                                           
version operators the package needs to specify at least 'cabal-version: >=                                                                                                                                                                                                         
1.8'. 
```